### PR TITLE
feature: TRACEFOSS-1171 removed the validation on controller level to…

### DIFF
--- a/backend/src/integration/groovy/org/eclipse/tractusx/traceability/investigations/adapters/rest/PublisherInvestigationsControllerIT.groovy
+++ b/backend/src/integration/groovy/org/eclipse/tractusx/traceability/investigations/adapters/rest/PublisherInvestigationsControllerIT.groovy
@@ -177,7 +177,7 @@ class PublisherInvestigationsControllerIT extends IntegrationSpecification imple
                 .post("/api/investigations/1/update")
                 .then()
                 .statusCode(400)
-                .body(Matchers.containsString("Accept or Decline reasons should have at least 15 characters and at most 1000 characters"))
+                .body(Matchers.containsString("Reason should have at least 15 characters and at most 1000 characters"))
     }
 
     // will be fixed in: https://jira.catena-x.net/browse/TRACEFOSS-1063

--- a/backend/src/main/java/org/eclipse/tractusx/traceability/investigations/adapters/rest/InvestigationsController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/traceability/investigations/adapters/rest/InvestigationsController.java
@@ -195,7 +195,7 @@ public class InvestigationsController {
     @PreAuthorize("hasAnyRole('ROLE_SUPERVISOR')")
     @PostMapping("/{investigationId}/update")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void updateInvestigation(@PathVariable Long investigationId, @Valid @RequestBody UpdateInvestigationRequest updateInvestigationRequest) {
+    public void updateInvestigation(@PathVariable Long investigationId, @RequestBody UpdateInvestigationRequest updateInvestigationRequest) {
         validate(updateInvestigationRequest);
         logger.info(API_LOG_START + "/{}/update with params {}", investigationId, updateInvestigationRequest);
         investigationsPublisherService.updateInvestigationPublisher(traceabilityProperties.getBpn(), investigationId, updateInvestigationRequest.status(), updateInvestigationRequest.reason());

--- a/backend/src/main/java/org/eclipse/tractusx/traceability/investigations/adapters/rest/validation/UpdateInvestigationValidator.java
+++ b/backend/src/main/java/org/eclipse/tractusx/traceability/investigations/adapters/rest/validation/UpdateInvestigationValidator.java
@@ -61,7 +61,7 @@ public class UpdateInvestigationValidator {
 			}
 
 			if (reason.length() < MINIMUM_REASON_CHARACTERS_SIZE || reason.length() > MAXIMUM_REASON_CHARACTERS_SIZE) {
-				throw new UpdateInvestigationValidationException("Close reason should have at least %d characters and at most %d characters".formatted(MINIMUM_REASON_CHARACTERS_SIZE, MAXIMUM_REASON_CHARACTERS_SIZE));
+				throw new UpdateInvestigationValidationException("Reason should have at least %d characters and at most %d characters".formatted(MINIMUM_REASON_CHARACTERS_SIZE, MAXIMUM_REASON_CHARACTERS_SIZE));
 			}
 		}
 	}


### PR DESCRIPTION
This fix is necessary to address the testing issues. 
Due to the adding of validation on controller level we blocked the acknowledge because it provides no reason within the body. As acknowledge should not have a reason and we already have a full functional validation within the controller implementation, I have removed the Validation on Controller level.