### PR TITLE
chore(documentation):[TRACEFOSS-XXX] changed links to tractusx, corrected doc after merge of tracefoss front- and backend

### DIFF
--- a/backend/src/test/java/org/eclipse/tractusx/traceability/investigations/domain/model/InvestigationReceiverTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/traceability/investigations/domain/model/InvestigationReceiverTest.java
@@ -67,7 +67,7 @@ class InvestigationReceiverTest {
         investigation = receiverInvestigationWithStatus(status);
 
         assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
-            investigation.acknowledge();
+            investigation.acknowledge(testNotification());
         });
 
         assertEquals(status, investigation.getInvestigationStatus());
@@ -83,7 +83,7 @@ class InvestigationReceiverTest {
         investigation = receiverInvestigationWithStatus(status);
 
         assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
-            investigation.acknowledge();
+            investigation.acknowledge(testNotification());
         });
 
         assertEquals(status, investigation.getInvestigationStatus());
@@ -99,7 +99,7 @@ class InvestigationReceiverTest {
         investigation = receiverInvestigationWithStatus(status);
 
         assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
-            investigation.acknowledge();
+            investigation.acknowledge(testNotification());
         });
 
         assertEquals(status, investigation.getInvestigationStatus());
@@ -115,7 +115,7 @@ class InvestigationReceiverTest {
         investigation = receiverInvestigationWithStatus(status);
 
         assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
-            investigation.acknowledge();
+            investigation.acknowledge(testNotification());
         });
 
         assertEquals(status, investigation.getInvestigationStatus());
@@ -131,7 +131,7 @@ class InvestigationReceiverTest {
         investigation = receiverInvestigationWithStatus(status);
 
         assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
-            investigation.accept("random reason");
+            investigation.accept("random reason", testNotification());
         });
 
         assertEquals(status, investigation.getInvestigationStatus());
@@ -147,7 +147,7 @@ class InvestigationReceiverTest {
         investigation = receiverInvestigationWithStatus(status);
 
         assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
-            investigation.accept("random reason");
+            investigation.accept("random reason", testNotification());
         });
 
         assertEquals(status, investigation.getInvestigationStatus());
@@ -163,7 +163,7 @@ class InvestigationReceiverTest {
         investigation = receiverInvestigationWithStatus(status);
 
         assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
-            investigation.accept("random reason");
+            investigation.accept("random reason", testNotification());
         });
 
         assertEquals(status, investigation.getInvestigationStatus());
@@ -179,7 +179,7 @@ class InvestigationReceiverTest {
         investigation = receiverInvestigationWithStatus(status);
 
         assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
-            investigation.accept("random reason");
+            investigation.accept("random reason", testNotification());
         });
 
         assertEquals(status, investigation.getInvestigationStatus());
@@ -195,7 +195,7 @@ class InvestigationReceiverTest {
         investigation = receiverInvestigationWithStatus(status);
 
         assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
-            investigation.accept("random reason");
+            investigation.accept("random reason", testNotification());
         });
 
         assertEquals(status, investigation.getInvestigationStatus());
@@ -247,7 +247,7 @@ class InvestigationReceiverTest {
         investigation = receiverInvestigationWithStatus(status);
 
         assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
-            investigation.decline("some-reason");
+            investigation.decline("some-reason", testNotification());
         });
 
         assertEquals(status, investigation.getInvestigationStatus());
@@ -263,7 +263,7 @@ class InvestigationReceiverTest {
         investigation = receiverInvestigationWithStatus(status);
 
         assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
-            investigation.decline("some-reason");
+            investigation.decline("some-reason", testNotification());
         });
 
         assertEquals(status, investigation.getInvestigationStatus());
@@ -279,7 +279,7 @@ class InvestigationReceiverTest {
         investigation = receiverInvestigationWithStatus(status);
 
         assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
-            investigation.decline("some-reason");
+            investigation.decline("some-reason", testNotification());
         });
 
         assertEquals(status, investigation.getInvestigationStatus());
@@ -295,7 +295,7 @@ class InvestigationReceiverTest {
         investigation = receiverInvestigationWithStatus(status);
 
         assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
-            investigation.decline("some-reason");
+            investigation.decline("some-reason", testNotification());
         });
 
         assertEquals(status, investigation.getInvestigationStatus());
@@ -311,7 +311,7 @@ class InvestigationReceiverTest {
         investigation = receiverInvestigationWithStatus(status);
 
         assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
-            investigation.decline("some-reason");
+            investigation.decline("some-reason", testNotification());
         });
 
         assertEquals(status, investigation.getInvestigationStatus());
@@ -327,7 +327,7 @@ class InvestigationReceiverTest {
         investigation = receiverInvestigationWithStatus(status);
 
         assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
-            investigation.decline("some-reason");
+            investigation.decline("some-reason", testNotification());
         });
 
         assertEquals(status, investigation.getInvestigationStatus());
@@ -622,19 +622,6 @@ class InvestigationReceiverTest {
 		assertEquals(DECLINED, investigation.getInvestigationStatus());
         assertEquals(DECLINED, notification.getInvestigationStatus());
 	}
-
-
-    @Test
-    @DisplayName("Close Investigation successfully")
-    void closeInvestigationSuccessfully() {
-
-        investigation = receiverInvestigationWithStatus(CREATED);
-        investigation.close(new BPN("BPNL000000000001"),"some reason");
-        assertEquals(CLOSED, investigation.getInvestigationStatus());
-
-    }
-
-
 
 	//util functions
 	private Investigation receiverInvestigationWithStatus(InvestigationStatus status) {

--- a/backend/src/test/java/org/eclipse/tractusx/traceability/investigations/domain/model/InvestigationReceiverTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/traceability/investigations/domain/model/InvestigationReceiverTest.java
@@ -43,7 +43,7 @@ class InvestigationReceiverTest {
 
 	@Test
 	@DisplayName("Forbid Acknowledge Investigation with disallowed status")
-	void forbidAcknowledgeInvestigationWithDisallowedStatus() {
+	void forbidAcknowledgeInvestigationWithStatusCreated() {
 
 		// Given
 		InvestigationStatus status = CREATED;
@@ -56,6 +56,152 @@ class InvestigationReceiverTest {
 		assertEquals(status, investigation.getInvestigationStatus());
 
 	}
+
+    @Test
+    @DisplayName("Forbid Acknowledge Investigation with status canceled")
+    void forbidAcknowledgeInvestigationWithStatusCanceled() {
+
+        // Given
+        InvestigationStatus status = CANCELED;
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.acknowledge();
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Acknowledge Investigation with status accepted")
+    void forbidAcknowledgeInvestigationWithStatusAccepted() {
+
+        // Given
+        InvestigationStatus status = ACCEPTED;
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.acknowledge();
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Acknowledge Investigation with status Declined")
+    void forbidAcknowledgeInvestigationWithStatusDeclined() {
+
+        // Given
+        InvestigationStatus status = DECLINED;
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.acknowledge();
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Acknowledge Investigation with status Closed")
+    void forbidAcknowledgeInvestigationWithStatusClosed() {
+
+        // Given
+        InvestigationStatus status = CLOSED;
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.acknowledge();
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Accept Investigation with status Closed")
+    void forbidAcceptInvestigationWithStatusClosed() {
+
+        // Given
+        InvestigationStatus status = CLOSED;
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.accept("random reason");
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Accept Investigation with status sent")
+    void forbidAcceptInvestigationWithStatusSent() {
+
+        // Given
+        InvestigationStatus status = SENT;
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.accept("random reason");
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Accept Investigation with status received")
+    void forbidAcceptInvestigationWithStatusReceived() {
+
+        // Given
+        InvestigationStatus status = RECEIVED;
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.accept("random reason");
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Accept Investigation with status declined")
+    void forbidAcceptInvestigationWithStatusDeclined() {
+
+        // Given
+        InvestigationStatus status = DECLINED;
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.accept("random reason");
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Acknowledge Investigation with status canceled")
+    void forbidAcceptInvestigationWithStatusCanceled() {
+
+        // Given
+        InvestigationStatus status = CANCELED;
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.accept("random reason");
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+
 
 	@Test
 	@DisplayName("Forbid Accept Investigation with disallowed status")
@@ -89,6 +235,361 @@ class InvestigationReceiverTest {
 
 	}
 
+    @Test
+    @DisplayName("Forbid Decline Investigation with status sent")
+    void forbidDeclineInvestigationWithStatusSent() {
+
+        InvestigationStatus status = SENT;
+
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.decline("some-reason");
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Decline Investigation with status received")
+    void forbidDeclineInvestigationWithStatusReceived() {
+
+        InvestigationStatus status = RECEIVED;
+
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.decline("some-reason");
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Decline Investigation with status accepted")
+    void forbidDeclineInvestigationWithStatusAccepted() {
+
+        InvestigationStatus status = ACCEPTED;
+
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.decline("some-reason");
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Decline Investigation with status declined")
+    void forbidDeclineInvestigationWithStatusDeclined() {
+
+        InvestigationStatus status = DECLINED;
+
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.decline("some-reason");
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Decline Investigation with status canceled")
+    void forbidDeclineInvestigationWithStatusCanceled() {
+
+        InvestigationStatus status = CANCELED;
+
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.decline("some-reason");
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Decline Investigation with status closed")
+    void forbidDeclineInvestigationWithStatusClosed() {
+
+        InvestigationStatus status = CLOSED;
+
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.decline("some-reason");
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Close Investigation with status canceled")
+    void forbidCloseInvestigationWithStatusCanceled() {
+
+        InvestigationStatus status = CANCELED;
+
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.close(new BPN("BPNL000000000001"),"some-reason");
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Close Investigation with status closed")
+    void forbidCloseInvestigationWithStatusClosed() {
+
+        InvestigationStatus status = CLOSED;
+
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.close(new BPN("BPNL000000000001"),"some-reason");
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Send Investigation with status sent")
+    void forbidSendInvestigationWithStatusSent() {
+
+        InvestigationStatus status = SENT;
+
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.send(new BPN("BPNL000000000001"));
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Send Investigation with status received")
+    void forbidSendInvestigationWithStatusReceived() {
+
+        InvestigationStatus status = RECEIVED;
+
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.send(new BPN("BPNL000000000001"));
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Send Investigation with status acknowledged")
+    void forbidSendInvestigationWithStatusAcknowledged() {
+
+        InvestigationStatus status = ACKNOWLEDGED;
+
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.send(new BPN("BPNL000000000001"));
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Send Investigation with status accepted")
+    void forbidSendInvestigationWithStatusAccepted() {
+
+        InvestigationStatus status = ACCEPTED;
+
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.send(new BPN("BPNL000000000001"));
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Send Investigation with status declined")
+    void forbidSendInvestigationWithStatusDeclined() {
+
+        InvestigationStatus status = DECLINED;
+
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.send(new BPN("BPNL000000000001"));
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Send Investigation with status canceled")
+    void forbidSendInvestigationWithStatusCanceled() {
+
+        InvestigationStatus status = CANCELED;
+
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.send(new BPN("BPNL000000000001"));
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Send Investigation with status closed")
+    void forbidSendInvestigationWithStatusClosed() {
+
+        InvestigationStatus status = CLOSED;
+
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.send(new BPN("BPNL000000000001"));
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Cancel Investigation with status sent")
+    void forbidCancelInvestigationWithStatusSent() {
+
+        InvestigationStatus status = SENT;
+
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.cancel(new BPN("BPNL000000000001"));
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Cancel Investigation with status received")
+    void forbidCancelInvestigationWithStatusReceived() {
+
+        InvestigationStatus status = RECEIVED;
+
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.cancel(new BPN("BPNL000000000001"));
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Cancel Investigation with status acknowledged")
+    void forbidCancelInvestigationWithStatusAcknowledged() {
+
+        InvestigationStatus status = ACKNOWLEDGED;
+
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.cancel(new BPN("BPNL000000000001"));
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Cancel Investigation with status accepted")
+    void forbidCancelInvestigationWithStatusAccepted() {
+
+        InvestigationStatus status = ACCEPTED;
+
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.cancel(new BPN("BPNL000000000001"));
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Cancel Investigation with status declined")
+    void forbidCancelInvestigationWithStatusDeclined() {
+
+        InvestigationStatus status = DECLINED;
+
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.cancel(new BPN("BPNL000000000001"));
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Cancel Investigation with status canceled")
+    void forbidCancelInvestigationWithStatusCanceled() {
+
+        InvestigationStatus status = CANCELED;
+
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.cancel(new BPN("BPNL000000000001"));
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+    @Test
+    @DisplayName("Forbid Cancel Investigation with status closed")
+    void forbidCancelInvestigationWithStatusClosed() {
+
+        InvestigationStatus status = CLOSED;
+
+        investigation = receiverInvestigationWithStatus(status);
+
+        assertThrows(InvestigationStatusTransitionNotAllowed.class, () -> {
+            investigation.cancel(new BPN("BPNL000000000001"));
+        });
+
+        assertEquals(status, investigation.getInvestigationStatus());
+
+    }
+
+
+
+
 	@Test
 	@DisplayName("Acknowledge Investigation successfully")
 	void acknowledgeInvestigationSuccessfully() {
@@ -116,6 +617,16 @@ class InvestigationReceiverTest {
 		assertEquals(DECLINED, investigation.getInvestigationStatus());
 
 	}
+
+    @Test
+    @DisplayName("Close Investigation successfully")
+    void closeInvestigationSuccessfully() {
+
+        investigation = receiverInvestigationWithStatus(CREATED);
+        investigation.close(new BPN("BPNL000000000001"),"some reason");
+        assertEquals(CLOSED, investigation.getInvestigationStatus());
+
+    }
 
 
 	//util functions

--- a/docs/src/docs/administration/backend-configuration.adoc
+++ b/docs/src/docs/administration/backend-configuration.adoc
@@ -13,7 +13,7 @@ The OAuth2, Vault configuration / secrets depend on your setup and might need to
 
 [source,yaml]
 ----
-include::../../../../charts/traceability-foss-backend/values.yaml[lines=121..-1]
+include::../../../../charts/traceability-foss/values.yaml[lines=121..-1]
 ----
 
 === Values explained

--- a/docs/src/docs/administration/frontend-configuration.adoc
+++ b/docs/src/docs/administration/frontend-configuration.adoc
@@ -15,10 +15,10 @@ The OAuth2, Vault configuration / secrets depend on your setup and might need to
 // TODO enable url include of values.yaml file
 // [source,yaml]
 // ----
-// include::https://github.com/eclipse-tractusx/traceability-foss-frontend/blob/main/charts/traceability-foss-frontend/values.yaml[lines=91..-1]
+// include::https://github.com/eclipse-tractusx/traceability-foss/blob/main/charts/traceability-foss/values.yaml[lines=91..-1]
 // ----
 
-values.yaml https://github.com/eclipse-tractusx/traceability-foss-frontend/blob/main/charts/traceability-foss-frontend/values.yaml
+values.yaml https://github.com/eclipse-tractusx/traceability-foss/blob/main/charts/traceability-foss/values.yaml
 
 === Values explained
 
@@ -38,7 +38,7 @@ The hostname of the app.
 The tls settings of the app.
 
 ==== <livenessProbe>
-Following Catena-X Helm Best Practices https://catenax-ng.github.io/docs/kubernetes-basics/helm
+Following Tractus-X Helm Best Practices https://eclipse-tractusx.github.io/docs/kubernetes-basics/helm
 
 ==== <readinessProbe>
-Following Catena-X Helm Best Practices https://catenax-ng.github.io/docs/kubernetes-basics/helm
+Following Tractus-X Helm Best Practices https://eclipse-tractusx.github.io/docs/kubernetes-basics/helm

--- a/docs/src/docs/administration/frontend-configuration.adoc
+++ b/docs/src/docs/administration/frontend-configuration.adoc
@@ -12,12 +12,6 @@ The OAuth2, Vault configuration / secrets depend on your setup and might need to
 
 == Helm configuration Trace-X Frontend (values.yaml)
 
-// TODO enable url include of values.yaml file
-// [source,yaml]
-// ----
-// include::https://github.com/eclipse-tractusx/traceability-foss/blob/main/charts/traceability-foss/values.yaml[lines=91..-1]
-// ----
-
 values.yaml https://github.com/eclipse-tractusx/traceability-foss/blob/main/charts/traceability-foss/values.yaml
 
 === Values explained
@@ -38,7 +32,7 @@ The hostname of the app.
 The tls settings of the app.
 
 ==== <livenessProbe>
-Following Tractus-X Helm Best Practices https://eclipse-tractusx.github.io/docs/kubernetes-basics/helm
+Following Tractus-X Helm Best Practices https://eclipse-tractusx.github.io/docs/release/
 
 ==== <readinessProbe>
-Following Tractus-X Helm Best Practices https://eclipse-tractusx.github.io/docs/kubernetes-basics/helm
+Following Tractus-X Helm Best Practices https://eclipse-tractusx.github.io/docs/release/

--- a/docs/src/docs/administration/installation.adoc
+++ b/docs/src/docs/administration/installation.adoc
@@ -1,12 +1,8 @@
 = Installation
 
-The Trace-X Helm Backend repository can be found here:
+The Trace-X Helm repository can be found here:
 
-https://eclipse-tractusx.github.io/traceability-foss-backend/index.yaml
-
-The Trace-X Helm Frontend repository can be found here:
-
-https://eclipse-tractusx.github.io/traceability-foss-frontend/index.yaml
+https://eclipse-tractusx.github.io/traceability-foss/index.yaml
 
 Use the latest release of the "trace-x-helm" chart.
 It contains all required dependencies.
@@ -15,17 +11,16 @@ Supply the required configuration properties (see chapter xref:configuration.ado
 
 == Deployment using Helm
 
-Add the Trace-X Backend Helm repository:
+Add the Trace-X Helm repository:
 
 [listing]
-$ helm repo add traceability-foss-backend https://eclipse-tractusx.github.io/traceability-foss-backend
-$ helm repo add traceability-foss-frontend https://eclipse-tractusx.github.io/traceability-foss-frontend
+$ helm repo add traceability-foss https://eclipse-tractusx.github.io/traceability-foss
 
 Then install the Helm chart into your cluster:
 
 [listing]
-$ helm install -f your-values.yaml traceability-foss-backend traceability-foss-backend/traceability-foss-backend
-$ helm install -f your-values.yaml traceability-foss-frontend traceability-foss-frontend/traceability-foss-frontend
+$ helm install -f your-values.yaml traceability-foss traceability-foss/traceability-foss
+
 
 == Dependent values
 
@@ -46,14 +41,10 @@ Create a new Helm chart and use Trace-X as a dependency.
 
 [source,yaml]
 dependencies:
-  - name: traceability-foss-frontend
-    alias: frontend
+  - name: traceability-foss
+    alias: traceability-foss
     version: x.x.x
-    repository: "https://eclipse-tractusx.github.io/traceability-foss-frontend/"
-  - name: traceability-foss-backend
-    alias: backend
-    version: x.x.x
-    repository: "https://eclipse-tractusx.github.io/traceability-foss-backend/"
+    repository: "https://eclipse-tractusx.github.io/traceability-foss/"
 
 Then provide your configuration as the values.yaml of that chart.
 


### PR DESCRIPTION
- changed links from ...catenax_ng... to ...eclipse-tractusx...
- corrected parts where tracefoss front- and backend parts were separated (after merge it needed to be done)
- Added Unit tests