### PR TITLE
chore: TRACEFOSS-XXX bump cypress-io/github-action from 5.7.1 to 5.8.0

### DIFF
--- a/.github/workflows/e2e-tests-xray_frontend.yml
+++ b/.github/workflows/e2e-tests-xray_frontend.yml
@@ -88,7 +88,7 @@ jobs:
           node-version: 18.x
 
       - name: Cypress run all tests
-        uses: cypress-io/github-action@v5.7.2 # use the explicit version number
+        uses: cypress-io/github-action@v5.8.0 # use the explicit version number
         with:
           start: npm start
           wait-on: "http://localhost:4200"
@@ -143,7 +143,7 @@ jobs:
           node-version: 18.x
 
       - name: Cypress run all tests
-        uses: cypress-io/github-action@v5.7.2 # use the explicit version number
+        uses: cypress-io/github-action@v5.8.0 # use the explicit version number
         with:
           start: npm start
           wait-on: "http://localhost:4200"
@@ -206,7 +206,7 @@ jobs:
         run: npx playwright install --with-deps webkit
 
       - name: Cypress run all tests
-        uses: cypress-io/github-action@v5.7.2 # use the explicit version number
+        uses: cypress-io/github-action@v5.8.0 # use the explicit version number
         with:
           start: npm start
           wait-on: "http://localhost:4200"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Changed logic of merging response from irs to match the correct ids of the relationships
 - Updated open api collection to detect security issues on rest api
 - Upgraded karma package dependency: socket.io-parser to 4.2.3 (to solve Insufficient validation when decoding a Socket.IO packet)
+- Upgraded cypress-io/github-action from 5.7.1 to 5.8.0
 
 ### Removed
 - Removed selection column on Customer Parts page


### PR DESCRIPTION
Handling this one:
https://github.com/eclipse-tractusx/traceability-foss/pull/144