### PR TITLE
fix: TRACEFOSS-600 one alert in receiver side

### DIFF
--- a/tx-backend/src/integration/groovy/org/eclipse/tractusx/traceability/qualitynotification/alert/rest/PublisherAlertsControllerIT.groovy
+++ b/tx-backend/src/integration/groovy/org/eclipse/tractusx/traceability/qualitynotification/alert/rest/PublisherAlertsControllerIT.groovy
@@ -116,7 +116,7 @@ class PublisherAlertsControllerIT extends IntegrationSpecification implements Ir
         }
 
         and:
-        assertAlertNotificationsSize(3)
+        assertAlertNotificationsSize(1)
 
         and:
         given()
@@ -503,7 +503,7 @@ class PublisherAlertsControllerIT extends IntegrationSpecification implements Ir
             assert asset.isActiveAlert()
         }
         and:
-        assertAlertNotificationsSize(3)
+        assertAlertNotificationsSize(1)
         and:
         given()
                 .header(jwtAuthorization(ADMIN))

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/qualitynotification/domain/service/NotificationPublisherService.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/qualitynotification/domain/service/NotificationPublisherService.java
@@ -104,8 +104,8 @@ public class NotificationPublisherService {
 
         List<Asset> assets = assetRepository.getAssetsById(assetIds);
 
-        assets.stream().map(asset -> createAlert(applicationBPN, description, targetDate, severity, asset, receiverBpn))
-                .forEach(notification::addNotification);
+        QualityNotificationMessage qualityNotificationMessage = createAlert(applicationBPN, description, targetDate, severity, assets, receiverBpn);
+        notification.addNotification(qualityNotificationMessage);
 
         assetService.setAssetsAlertStatus(notification);
         return notification;
@@ -132,7 +132,7 @@ public class NotificationPublisherService {
                 .build();
     }
 
-    private QualityNotificationMessage createAlert(BPN applicationBpn, String description, Instant targetDate, QualityNotificationSeverity severity, Asset affectedAsset, String targetBpn) {
+    private QualityNotificationMessage createAlert(BPN applicationBpn, String description, Instant targetDate, QualityNotificationSeverity severity, List<Asset> affectedAssets, String targetBpn) {
         final String notificationId = UUID.randomUUID().toString();
         final String messageId = UUID.randomUUID().toString();
         return QualityNotificationMessage.builder()
@@ -144,7 +144,7 @@ public class NotificationPublisherService {
                 .receiverManufacturerName(getManufacturerName(targetBpn))
                 .description(description)
                 .notificationStatus(QualityNotificationStatus.CREATED)
-                .affectedParts(List.of(new QualityNotificationAffectedPart(affectedAsset.getId())))
+                .affectedParts(affectedAssets.stream().map(Asset::getId).map(QualityNotificationAffectedPart::new).toList())
                 .targetDate(targetDate)
                 .severity(severity)
                 .edcNotificationId(notificationId)


### PR DESCRIPTION
we currently create quality notifications for each asset in alert. 
this changes it to create one qualityNotification with affected assetIds. 