### PR TITLE
bug: 392 limit filter param to 1100 characters

### DIFF
--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/common/request/SearchCriteriaRequestParam.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/common/request/SearchCriteriaRequestParam.java
@@ -47,7 +47,7 @@ public class SearchCriteriaRequestParam {
     @ArraySchema(arraySchema = @Schema(description = "Filter Criteria", additionalProperties = Schema.AdditionalPropertiesValue.FALSE, example = "owner,EQUAL,OWN"), maxItems = Integer.MAX_VALUE)
     List<String> filter;
 
-    public List<@Size(max = 1000, message = "Filter string should not be longer than 1000 characters.") String> getFilter() {
+    public List<@Size(max = 1100, message = "Filter string should not be longer than 1100 characters.") String> getFilter() {
         return filter;
     }
 


### PR DESCRIPTION
resolves eclipse-tractusx/traceability-foss#392
