### PR TITLE
chore(bug): 528 disabled sorting tooltip on dashboard tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Removed
 - Removed EDC notification asset classes and replaced with IRS lib implementation
+- [#528](https://github.com/eclipse-tractusx/traceability-foss/issues/528) Removed sorting tooltip on quality incidents tables on dashboard page
 
 ## [10.5.0 - 22.02.2024]
 

--- a/frontend/src/app/modules/shared/components/table/table.component.html
+++ b/frontend/src/app/modules/shared/components/table/table.component.html
@@ -234,7 +234,7 @@ SPDX-License-Identifier: Apache-2.0
           matTooltipPosition="above"
           [class.mdc-tooltip--multiline]="true"
           [matTooltipShowDelay]="1000"
-          matTooltipDisabled="{{labelId.startsWith('dashboard')}}"
+          matTooltipDisabled="{{labelId?.startsWith('dashboard')}}"
           [mat-sort-header]="tableConfig.sortableColumns?.[column] ? '' : null"
           [disabled]="!tableConfig.sortableColumns?.[column]"
           mat-header-cell

--- a/frontend/src/app/modules/shared/components/table/table.component.html
+++ b/frontend/src/app/modules/shared/components/table/table.component.html
@@ -234,6 +234,7 @@ SPDX-License-Identifier: Apache-2.0
           matTooltipPosition="above"
           [class.mdc-tooltip--multiline]="true"
           [matTooltipShowDelay]="1000"
+          matTooltipDisabled="{{labelId.startsWith('dashboard')}}"
           [mat-sort-header]="tableConfig.sortableColumns?.[column] ? '' : null"
           [disabled]="!tableConfig.sortableColumns?.[column]"
           mat-header-cell


### PR DESCRIPTION
resolves eclipse-tractusx/traceability-foss#528
