### PR TITLE
feature: #736 add contractAgreementId as searchable field for /contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ _**For better traceability add the corresponding GitHub issue number in each cha
 - Added overview of the scheduler tasks in documentation
 - #706 Created notification classes to support both alert and investigations
 - #706 Notification controller having the same endpoints as alerts and investigations controllers
+- #736 add contractAgreementId as searchable field for /contracts
 
 ### Changed
 - #709 Bumped spring-core from 6.0.17 to 6.1.5

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/contracts/application/mapper/ContractFieldMapper.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/contracts/application/mapper/ContractFieldMapper.java
@@ -27,7 +27,8 @@ import java.util.Map;
 public class ContractFieldMapper extends BaseRequestFieldMapper {
     private static final Map<String, String> SUPPORTED_CONTRACT_FILTER_FIELDS = Map.ofEntries(
             Map.entry("created", "created"),
-            Map.entry("id", "id")
+            Map.entry("id", "id"),
+            Map.entry("contractAgreementId", "contractAgreementId")
     );
 
     @Override

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/contracts/application/mapper/ContractFieldMapper.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/contracts/application/mapper/ContractFieldMapper.java
@@ -28,7 +28,7 @@ public class ContractFieldMapper extends BaseRequestFieldMapper {
     private static final Map<String, String> SUPPORTED_CONTRACT_FILTER_FIELDS = Map.ofEntries(
             Map.entry("created", "created"),
             Map.entry("id", "id"),
-            Map.entry("contractAgreementId", "contractAgreementId")
+            Map.entry("contractId", "contractAgreementId")
     );
 
     @Override


### PR DESCRIPTION
resolves eclipse-tractusx/traceability-foss#736
