### PR TITLE
feature: downgrade to urn:bamm:io.catenax.single_level_usage_as_built…

### DIFF
--- a/tx-backend/testdata/CX_Testdata_MessagingTest_v0.0.13.json
+++ b/tx-backend/testdata/CX_Testdata_MessagingTest_v0.0.13.json
@@ -154,7 +154,7 @@
           }
         }
       ],
-      "urn:bamm:io.catenax.single_level_usage_as_built:2.0.0#SingleLevelUsageAsBuilt" : [
+      "urn:bamm:io.catenax.single_level_usage_as_built:1.0.0#SingleLevelUsageAsBuilt" : [
         {
           "catenaXId" : "urn:uuid:7eeeac86-7b69-444d-81e6-655d0f1513bd",
           "customers" : [
@@ -215,7 +215,7 @@
           }
         }
       ],
-      "urn:bamm:io.catenax.single_level_usage_as_built:2.0.0#SingleLevelUsageAsBuilt" : [
+      "urn:bamm:io.catenax.single_level_usage_as_built:1.0.0#SingleLevelUsageAsBuilt" : [
         {
           "catenaXId" : "urn:uuid:1d2d8480-90a5-4a17-9ecb-2ff039d35fec",
           "customers" : [
@@ -350,7 +350,7 @@
           }
         }
       ],
-      "urn:bamm:io.catenax.single_level_usage_as_built:2.0.0#SingleLevelUsageAsBuilt" : [
+      "urn:bamm:io.catenax.single_level_usage_as_built:1.0.0#SingleLevelUsageAsBuilt" : [
         {
           "catenaXId" : "urn:uuid:5205f736-8fc2-4585-b869-6bf36842369a",
           "customers" : [
@@ -411,7 +411,7 @@
           }
         }
       ],
-      "urn:bamm:io.catenax.single_level_usage_as_built:2.0.0#SingleLevelUsageAsBuilt" : [
+      "urn:bamm:io.catenax.single_level_usage_as_built:1.0.0#SingleLevelUsageAsBuilt" : [
         {
           "catenaXId" : "urn:uuid:4e390dab-707f-446e-bfbe-653f6f5b1f37",
           "customers" : [
@@ -546,7 +546,7 @@
           }
         }
       ],
-      "urn:bamm:io.catenax.single_level_usage_as_built:2.0.0#SingleLevelUsageAsBuilt" : [
+      "urn:bamm:io.catenax.single_level_usage_as_built:1.0.0#SingleLevelUsageAsBuilt" : [
         {
           "catenaXId" : "urn:uuid:f11ddc62-3bd5-468f-b7b0-110fe13ed0cd",
           "customers" : [
@@ -607,7 +607,7 @@
           }
         }
       ],
-      "urn:bamm:io.catenax.single_level_usage_as_built:2.0.0#SingleLevelUsageAsBuilt" : [
+      "urn:bamm:io.catenax.single_level_usage_as_built:1.0.0#SingleLevelUsageAsBuilt" : [
         {
           "catenaXId" : "urn:uuid:4a5e9ff6-2d5c-4510-a90e-d55af3ba502f",
           "customers" : [
@@ -742,7 +742,7 @@
           }
         }
       ],
-      "urn:bamm:io.catenax.single_level_usage_as_built:2.0.0#SingleLevelUsageAsBuilt" : [
+      "urn:bamm:io.catenax.single_level_usage_as_built:1.0.0#SingleLevelUsageAsBuilt" : [
         {
           "catenaXId" : "urn:uuid:c47b9f8b-48d0-4ef4-8f0b-e965a225cb8d",
           "customers" : [
@@ -803,7 +803,7 @@
           }
         }
       ],
-      "urn:bamm:io.catenax.single_level_usage_as_built:2.0.0#SingleLevelUsageAsBuilt" : [
+      "urn:bamm:io.catenax.single_level_usage_as_built:1.0.0#SingleLevelUsageAsBuilt" : [
         {
           "catenaXId" : "urn:uuid:6ec3f1db-2798-454b-a73f-0d21a8966c74",
           "customers" : [
@@ -862,7 +862,7 @@
           }
         }
       ],
-      "urn:bamm:io.catenax.single_level_usage_as_built:2.0.0#SingleLevelUsageAsBuilt" : [
+      "urn:bamm:io.catenax.single_level_usage_as_built:1.0.0#SingleLevelUsageAsBuilt" : [
         {
           "catenaXId" : "urn:uuid:1be6ec59-40fb-4993-9836-acb0e284b170",
           "customers" : [
@@ -1010,7 +1010,7 @@
           }
         }
       ],
-      "urn:bamm:io.catenax.single_level_usage_as_built:2.0.0#SingleLevelUsageAsBuilt" : [
+      "urn:bamm:io.catenax.single_level_usage_as_built:1.0.0#SingleLevelUsageAsBuilt" : [
         {
           "catenaXId" : "urn:uuid:1be6ec59-40fb-4993-9836-acb0e284fb01",
           "customers" : [
@@ -1122,7 +1122,7 @@
           }
         }
       ],
-      "urn:bamm:io.catenax.single_level_usage_as_built:2.0.0#SingleLevelUsageAsBuilt" : [
+      "urn:bamm:io.catenax.single_level_usage_as_built:1.0.0#SingleLevelUsageAsBuilt" : [
         {
           "catenaXId" : "urn:uuid:1be6ec59-40fb-4993-9836-acb0e284fa03",
           "customers" : [
@@ -2466,7 +2466,7 @@
     {
       "catenaXId" : "urn:uuid:254604ab-2153-45fb-8cad-54ef09f4070e",
       "bpnl" : "BPNL00000003CML1",
-      "urn:bamm:io.catenax.single_level_usage_as_built:2.0.0#SingleLevelUsageAsBuilt" : [
+      "urn:bamm:io.catenax.single_level_usage_as_built:1.0.0#SingleLevelUsageAsBuilt" : [
         {
           "catenaXId" : "urn:uuid:254604ab-2153-45fb-8cad-54ef09f4070e",
           "customers" : [
@@ -2567,7 +2567,7 @@
     {
       "catenaXId" : "urn:uuid:254604ab-2153-45fb-8cad-54ef09f4080f",
       "bpnl" : "BPNL00000003CNKC",
-      "urn:bamm:io.catenax.single_level_usage_as_built:2.0.0#SingleLevelUsageAsBuilt" : [
+      "urn:bamm:io.catenax.single_level_usage_as_built:1.0.0#SingleLevelUsageAsBuilt" : [
         {
           "catenaXId" : "urn:uuid:254604ab-2153-45fb-8cad-54ef09f4080f",
           "customers" : [


### PR DESCRIPTION
…:1.0.0#SingleLevelUsageAsBuilt because 2.0.0 is not in semantic hub